### PR TITLE
Load the SOLR config in a Dotenv compatible way

### DIFF
--- a/config/initializers/solr.rb
+++ b/config/initializers/solr.rb
@@ -1,1 +1,1 @@
-SOLR = YAML.load_file("#{Rails.root.to_s}/config/solr.yml")
+SOLR = YAML.load(ERB.new(IO.read("#{Rails.root.to_s}/config/solr.yml")).result)


### PR DESCRIPTION
When solr.yaml contains Dotenv-gem lines (e.g. url: <%= ENV['myUrl'] %>, these expression-printing tags were treated as literals rather than being translated into their corresponding variable values (stored in .env file). The error seen in the app logging is: ActionView::Template::Error (bad URI(is not URI?): <%= ENV['myUrl'] %>/): This commit fixes the situation.