### PR TITLE
Fix image zooming bug

### DIFF
--- a/app/views/image_zoom_large/index.html.erb
+++ b/app/views/image_zoom_large/index.html.erb
@@ -10,6 +10,6 @@
         id: "location",
         prefixUrl: "assets/seadragonImages/",
         autoResize: true,
-        tileSources: "//dlib.york.ac.uk/cgi-bin/iipsrv.fcgi?DeepZoom=<%= session['folio_image']%>.dzi"
+        tileSources: "//dlib.york.ac.uk/cgi-bin/iipsrv.fcgi?DeepZoom=<%= get_folio_image(session[:folio_id]) %>.dzi"
     });
 </script>


### PR DESCRIPTION
Resolve #27 bug as introduced at e124b036. Provide correct image path.

The bug is a consequence of a wider need to refactor/DRY code. Here is an idea of how we could start with
[OpenSeadragon and decorator pattern](https://docs.google.com/document/d/1tlIZ7ySy-V5Gr7opHRvpWpSk6ke0ZIk54LwmZD6JeVY/edit#bookmark=id.lsrv6ivkqqh1).