### PR TITLE
Fix - Show TNA search results details

### DIFF
--- a/app/views/search/_display_search_results.html.erb
+++ b/app/views/search/_display_search_results.html.erb
@@ -17,7 +17,7 @@
                    is_referenced_by = t[11]
                    place = t[12]
                    person = t[13]
-                   dates = t[14].sort_by { |s| s.scan(/\d+/).join } # Sort by dates digit only
+                   dates = t[14]&.sort_by { |s| s.scan(/\d+/).join } # Sort by dates digit only
                    search_type = (t[15] == :document ? :document : :entry) # Decide search type Document or Entry
                 %>
 


### PR DESCRIPTION
Fix presentation of following information
- dates
- person as combined from persons, senders, and addressees
- places
- facets brows with Dates and Places

Refactoring
- The above approach use direct fields on Document search results. This is not linked approach as for Entries. We ough to harmonise this approach across both search result types. The code uses case approach to distinguish documents from entries in order to produce correct @element_array for partial display e.g. order of elements has a meaning of fields for display.
- Facet browse with Dates and Places uses different facet_fields than the one from Entry document. TNA Document fields do not have "entry_" prefix. There is a hack to accommodate for result filtering with those facets in Document section. Sorl will return an empty result if one of the filter don't match value.
- We have 5 types of dates in the spreadsheet. Currently we do not present date types and accuracy information.

[WIP due to data bugs]
- Some facets are still missing as they are not populated for Documents fields for example there is not person_same_as_facet_ssim filed, section_type_facet_ssim, subject_facet_ssim, or facet for as_written Places.
- When browsing authority relevant TNA results are not provided as linked object are not created. For example has_model_ssim:RelatedPlace or RelatedAgent.