### PR TITLE
fix - extend TNA Documents searchable fields

### DIFF
--- a/app/helpers/tnw_common/simple_search_helper.rb
+++ b/app/helpers/tnw_common/simple_search_helper.rb
@@ -84,7 +84,11 @@ module TnwCommon
       language_new_tesim:#{sterm} ||
       repository_tesim:#{sterm} ||
       reference_tesim:#{sterm} ||
-      subject_new_tesim:#{sterm} "
+      subject_new_tesim:#{sterm} ||
+      publication_tesim:#{sterm} ||
+      tna_addressees_tesim:#{sterm} ||
+      tna_persons_tesim:#{sterm} ||
+      tna_senders_tesim:#{sterm}"
       #
       # All fields
       entry + document + "|| suggest:#{sterm}"


### PR DESCRIPTION
Extend search across publication, tna_persons, tna_senders, tna_addressees fields.