### PR TITLE
Fix: Use Discover images from manifest.json URL

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -1,6 +1,7 @@
 class IiifController < ApplicationController
   include IiifHelper
   include SearchesHelper
+  include RegisterFolioHelper
   layout 'default_layout'
 
   def index
@@ -21,15 +22,17 @@ class IiifController < ApplicationController
       # pass to the download method
       download
     else
-      image = get_image(params[:id])
-      if image != ''
+      image_source = get_tile_sources_for_folio(params[:id])
+      # Convert it to IIIF API v2
+      image_url = image_source.first.gsub(/\/info\.json/,"").gsub(/iiif\/3\/ark/,"iiif/2/ark")
+      if image_url != ''
         if params[:region].nil? || params[:size].nil? || params[:rotation].nil? || params[:quality].nil? ||
            (params[:region] == '') || (params[:size] == '') || (params[:rotation] == '') || (params[:quality] == '')
-          redirect_to "http://dlib.york.ac.uk/cgi-bin/iipsrv.fcgi?IIIF=#{image}/info.json"
+           redirect_to image_url
         # Let IIP on dlib handle incorrect params
         # IIP will crash on requests for regions bigger than the width/height of the image; could deal with that here
         else
-          redirect_to "http://dlib.york.ac.uk/cgi-bin/iipsrv.fcgi?IIIF=#{image}/#{params[:region]}/#{params[:size]}/#{params[:rotation]}/#{params[:quality]}.jpg"
+          redirect_to "#{image_url}/#{params[:region]}/#{params[:size]}/#{params[:rotation]}/#{params[:quality]}.jpg"
         end
       # If an incorrect id is requested, redirect to the 404 page
       else

--- a/app/models/folio.rb
+++ b/app/models/folio.rb
@@ -8,12 +8,12 @@ class Folio < ActiveFedora::Base
   include RdfType
   include DCTerms
 
-  belongs_to :register, predicate: ::RDF::DC.isPartOf
-  has_many :entries # , :dependent => :destroy
-  has_many :images, dependent: :destroy
+  # belongs_to :register, predicate: ::RDF::DC.isPartOf
+  # has_many :entries # , :dependent => :destroy
+  # has_many :images, dependent: :destroy
   # accepts_nested_attributes_for :entry, :allow_destroy => true, :reject_if => :all_blank
-  accepts_nested_attributes_for :image, allow_destroy: true, reject_if: :all_blank
-  directly_contains :images, has_member_relation: ::RDF::URI.new('http://pcdm.org/models#hasMember'), class_name: 'Image'
+  # accepts_nested_attributes_for :image, allow_destroy: true, reject_if: :all_blank
+  # directly_contains :images, has_member_relation: ::RDF::URI.new('http://pcdm.org/models#hasMember'), class_name: 'Image'
   # contains 'canvas', predicate: ::RDF::URI.new("http://pcdm.org/models#hasFile"), class_name: 'Canvas'
 
   # Adding a lot of relationships (eg. hasMember) with has_and_belongs_to_many causes an error (solr query too large);


### PR DESCRIPTION
Support new image location at existing [manifest.json files](https://archbishopsregisters.york.ac.uk/iiif/index):
- Use images from Discover IIIF API image v2 e.g. this URL https://archbishopsregisterstest.york.ac.uk/iiif/x633f229p/full/full/0/default.jpg
- Fix canvas bug with Fedora missing property. E.g. this URL will work now https://archbishopsregisterstest.york.ac.uk/iiif/canvas/x633f229p