### PR TITLE
fix: construct correct pid value for search

### DIFF
--- a/app/helpers/iiif_helper.rb
+++ b/app/helpers/iiif_helper.rb
@@ -121,7 +121,8 @@ include RegisterFolioHelper
     canvas = IIIF::Presentation::Canvas.new
     if i.nil?
       targets = @query_obj.solr_query('id:"' + resp[0]['isPartOf_ssim'].join + '/list_source"', fl = 'ordered_targets_ssim', rows = 1)['response']['docs'][0]['ordered_targets_ssim']
-      fol_num = "&folio=#{targets.find_index(pid) + 1}"
+      transformed_pid = "production/#{pid[0..1]}/#{pid[2..3]}/#{pid[4..5]}/#{pid[6..7]}/#{pid}"
+      fol_num = "&folio=#{targets.find_index(transformed_pid) + 1}"
     else
       fol_num = "&folio=#{i + 1}"
     end


### PR DESCRIPTION
Construct PIDs as stored in Fedora. Code is used to construct folio number counting from 1.